### PR TITLE
Enumerate tasks in Todo

### DIFF
--- a/Todo.md
+++ b/Todo.md
@@ -12,69 +12,69 @@ needed to build *lmdb-tui*. Use it to track progress and priorities.
 ## Phased Tasks
 
 ### Phase 0 – Bootstrap
-- [ ] **hi** Initialize Cargo binary crate `lmdb-tui`
-- [ ] **hi** CI workflow with clippy, fmt, test and build
-- [ ] **mid** Add dependencies: `crossterm`, `ratatui`, `heed`, `clap`, `tokio`
-- [ ] **mid** Basic `--help` and `--version` output
+001. [ ] **hi** Initialize Cargo binary crate `lmdb-tui`
+002. [ ] **hi** CI workflow with clippy, fmt, test and build
+003. [ ] **mid** Add dependencies: `crossterm`, `ratatui`, `heed`, `clap`, `tokio`
+004. [ ] **mid** Basic `--help` and `--version` output
 
 ### Phase 1 – Core View
-- [ ] **hi** FR-01: open existing LMDB environment and list databases
-- [ ] **hi** FR-02: display keys and values in scrollable list
-- [ ] **mid** FR-04: support read-only sessions
-- [ ] **mid** App state reducer and navigation stack
-- [ ] **mid** Unit tests for env open/list operations
+005. [ ] **hi** FR-01: open existing LMDB environment and list databases
+006. [ ] **hi** FR-02: display keys and values in scrollable list
+007. [ ] **mid** FR-04: support read-only sessions
+008. [ ] **mid** App state reducer and navigation stack
+009. [ ] **mid** Unit tests for env open/list operations
 
 ### Phase 2 – CRUD & Transactions
-- [ ] **hi** FR-03: CRUD operations inside read-write txn
-- [ ] **mid** FR-06: transaction management commands
-- [ ] **mid** FR-11: undo/redo stack
-- [ ] **mid** DB service layer (`db::*` modules)
-- [ ] **mid** Integration tests covering CRUD flows
+010. [ ] **hi** FR-03: CRUD operations inside read-write txn
+011. [ ] **mid** FR-06: transaction management commands
+012. [ ] **mid** FR-11: undo/redo stack
+013. [ ] **mid** DB service layer (`db::*` modules)
+014. [ ] **mid** Integration tests covering CRUD flows
 
 ### Phase 3 – Query Engine
-- [ ] **mid** FR-05: rich query modes (prefix, range, regex, JSONPath)
-- [ ] **mid** Implement `db::query` module with decoders
-- [ ] **mid** Snapshot tests for query UI
+015. [ ] **mid** FR-05: rich query modes (prefix, range, regex, JSONPath)
+016. [ ] **mid** Implement `db::query` module with decoders
+017. [ ] **mid** Snapshot tests for query UI
 
 ### Phase 4 – Visuals and Stats
-- [ ] **mid** FR-07: environment and DB statistics panes
-- [ ] **lo** FR-08: bookmarks and jump-to-key history
-- [ ] **mid** Background job queue for statistics (tokio tasks)
-- [ ] **mid** Benchmarks for scanning 1M keys/sec
+018. [ ] **mid** FR-07: environment and DB statistics panes
+019. [ ] **lo** FR-08: bookmarks and jump-to-key history
+020. [ ] **mid** Background job queue for statistics (tokio tasks)
+021. [ ] **mid** Benchmarks for scanning 1M keys/sec
 
 ### Phase 5 – Export & Import
-- [ ] **mid** FR-09: export/import in JSON or CSV
-- [ ] **mid** Command progress indicators
-- [ ] **lo** Validate values as JSON before export
+022. [ ] **mid** FR-09: export/import in JSON or CSV
+023. [ ] **mid** Command progress indicators
+024. [ ] **lo** Validate values as JSON before export
 
 ### Phase 6 – Polish & Docs
-- [ ] **mid** FR-10: configurable keybindings and themes
-- [ ] **lo** FR-12: embedded help screen with searchable palette
-- [ ] **mid** Packaging scripts: cross-build, Homebrew/Scoop manifests
-- [ ] **mid** Usage examples and screenshots in README
-- [ ] **mid** Document config format in `docs/`
+025. [ ] **mid** FR-10: configurable keybindings and themes
+026. [ ] **lo** FR-12: embedded help screen with searchable palette
+027. [ ] **mid** Packaging scripts: cross-build, Homebrew/Scoop manifests
+028. [ ] **mid** Usage examples and screenshots in README
+029. [ ] **mid** Document config format in `docs/`
 
 ### Future Enhancements
-- [ ] **lo** remote mode via agent process
-- [ ] **lo** gRPC server for automation
-- [ ] **lo** WebAssembly build
-- [ ] **lo** plugin API for custom decoders
+030. [ ] **lo** remote mode via agent process
+031. [ ] **lo** gRPC server for automation
+032. [ ] **lo** WebAssembly build
+033. [ ] **lo** plugin API for custom decoders
 
 ## Module Implementation
-- [ ] **hi** `app` main loop and state reducer
-- [ ] **hi** `ui` layouts and widgets using ratatui
-- [ ] **hi** `db::env` open/close env and query stats
-- [ ] **hi** `db::txn` safe wrapper over heed txns
-- [ ] **mid** `db::query` searching and decoding
-- [ ] **mid** `commands` CRUD, export/import, undo stack
-- [ ] **mid** `jobs` async workers and channels
-- [ ] **mid** `config` load/save YAML/TOML settings
-- [ ] **lo** `util` helpers (hex/utf-8, formatting)
-- [ ] **mid** `errors` define `AppError` via `thiserror`
+034. [ ] **hi** `app` main loop and state reducer
+035. [ ] **hi** `ui` layouts and widgets using ratatui
+036. [ ] **hi** `db::env` open/close env and query stats
+037. [ ] **hi** `db::txn` safe wrapper over heed txns
+038. [ ] **mid** `db::query` searching and decoding
+039. [ ] **mid** `commands` CRUD, export/import, undo stack
+040. [ ] **mid** `jobs` async workers and channels
+041. [ ] **mid** `config` load/save YAML/TOML settings
+042. [ ] **lo** `util` helpers (hex/utf-8, formatting)
+043. [ ] **mid** `errors` define `AppError` via `thiserror`
 
 ## Non-Functional Goals
-- [ ] **mid** Keep RSS under 200 MB via streaming
-- [ ] **hi** Maintain 60 fps while scanning 1M keys/sec
-- [ ] **mid** Colour-blind-friendly palette, honour `$NO_COLOR`
-- [ ] **mid** Audit crates to ensure no network I/O
+044. [ ] **mid** Keep RSS under 200 MB via streaming
+045. [ ] **hi** Maintain 60 fps while scanning 1M keys/sec
+046. [ ] **mid** Colour-blind-friendly palette, honour `$NO_COLOR`
+047. [ ] **mid** Audit crates to ensure no network I/O
 


### PR DESCRIPTION
## Summary
- enumerate tasks with 3-digit ids in `Todo.md`

## Testing
- `cargo fmt --all` *(fails: component not installed)*
- `cargo clippy --all-targets --all-features` *(fails: component not installed)*
- `cargo test` *(fails: could not find `Cargo.toml`)*


------
https://chatgpt.com/codex/tasks/task_e_6841d5f28db48320ab47afa83af0cb79