### PR TITLE
Implement task 002: add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Run fmt check
+        run: cargo fmt --all -- --check
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Build
+        run: cargo build --verbose
+      - name: Test
+        run: cargo test --verbose

--- a/Todo.md
+++ b/Todo.md
@@ -13,7 +13,7 @@ needed to build *lmdb-tui*. Use it to track progress and priorities.
 
 ### Phase 0 – Bootstrap
 001. [ ] **hi** Initialize Cargo binary crate `lmdb-tui`
-002. [ ] **hi** CI workflow with clippy, fmt, test and build
+002. [x] **hi** CI workflow with clippy, fmt, test and build
 003. [ ] **mid** Add dependencies: `crossterm`, `ratatui`, `heed`, `clap`, `tokio`
 004. [ ] **mid** Basic `--help` and `--version` output
 


### PR DESCRIPTION
## Summary
- add GitHub Actions CI workflow running fmt, clippy, build and tests
- mark CI workflow task as complete in Todo

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6841d786b3548320adb56dddcffe1f27