### PR TITLE
Implement tasks 003 and 004

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +328,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +580,7 @@ dependencies = [
  "clap",
  "crossterm",
  "heed",
+ "predicates",
  "ratatui",
  "tokio",
 ]
@@ -616,6 +635,21 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -749,7 +783,10 @@ checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
  "difflib",
+ "float-cmp",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]
@@ -831,10 +868,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [dev-dependencies]
 assert_cmd = "2"
+predicates = "3"
 
 [package.metadata]
 authors = ["TODO"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # lmdb-tui
 
 A terminal UI to explore LMDB environments.
+
+## Usage
+
+Print the help text:
+
+```bash
+lmdb-tui --help
+```
+
+Show the version:
+
+```bash
+lmdb-tui --version
+```

--- a/Todo.md
+++ b/Todo.md
@@ -14,8 +14,8 @@ needed to build *lmdb-tui*. Use it to track progress and priorities.
 ### Phase 0 – Bootstrap
 001. [x] **hi** Initialize Cargo binary crate `lmdb-tui`
 002. [x] **hi** CI workflow with clippy, fmt, test and build
-003. [ ] **mid** Add dependencies: `crossterm`, `ratatui`, `heed`, `clap`, `tokio`
-004. [ ] **mid** Basic `--help` and `--version` output
+003. [x] **mid** Add dependencies: `crossterm`, `ratatui`, `heed`, `clap`, `tokio`
+004. [x] **mid** Basic `--help` and `--version` output
 
 ### Phase 1 – Core View
 005. [ ] **hi** FR-01: open existing LMDB environment and list databases

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,8 +1,20 @@
 use assert_cmd::Command;
+use predicates::str::contains;
 
 #[test]
 fn shows_version() {
     let mut cmd = Command::cargo_bin("lmdb-tui").unwrap();
     cmd.arg("--version");
-    cmd.assert().success();
+    cmd.assert()
+        .success()
+        .stdout(contains(env!("CARGO_PKG_VERSION")));
+}
+
+#[test]
+fn shows_help() {
+    let mut cmd = Command::cargo_bin("lmdb-tui").unwrap();
+    cmd.arg("--help");
+    cmd.assert()
+        .success()
+        .stdout(contains("Simple LMDB TUI explorer"));
 }


### PR DESCRIPTION
## Summary
- add `predicates` dev dependency and CLI tests
- mark tasks 003 and 004 as complete
- document `--help` and `--version` usage

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6841d8fb63348320aa18ea482141439f