### PR TITLE
Add env listing tests

### DIFF
--- a/tests/env.rs
+++ b/tests/env.rs
@@ -1,5 +1,5 @@
 use heed::types::{Str, Unit};
-use lmdb_tui::db::env::{list_databases, open_env};
+use lmdb_tui::db::env::{list_databases, list_entries, open_env};
 use tempfile::tempdir;
 
 #[test]
@@ -13,5 +13,37 @@ fn lists_created_databases() -> anyhow::Result<()> {
     let mut names = list_databases(&env)?;
     names.sort();
     assert_eq!(names, vec!["first".to_string(), "second".to_string()]);
+    Ok(())
+}
+
+#[test]
+fn lists_entries() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let env = open_env(dir.path(), false)?;
+    let mut wtxn = env.write_txn()?;
+    let db = env.create_database::<Str, Str>(&mut wtxn, Some("entries"))?;
+    db.put(&mut wtxn, "a", "1")?;
+    db.put(&mut wtxn, "b", "2")?;
+    db.put(&mut wtxn, "c", "3")?;
+    wtxn.commit()?;
+
+    let entries = list_entries(&env, "entries", 2)?;
+    assert_eq!(
+        entries,
+        vec![
+            ("a".to_string(), b"1".to_vec()),
+            ("b".to_string(), b"2".to_vec()),
+        ]
+    );
+    Ok(())
+}
+
+#[test]
+fn opens_env_read_only() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let env_rw = open_env(dir.path(), false)?;
+    env_rw.prepare_for_closing().wait();
+    let env = open_env(dir.path(), true)?;
+    let _rtxn = env.read_txn()?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- test listing database entries in `list_entries`
- ensure `open_env` works in read-only mode

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6841fba7e4d483209cf84e5ee5ba8726