### PR TITLE
Implement CRUD & transaction layer

### DIFF
--- a/Todo.md
+++ b/Todo.md
@@ -25,11 +25,11 @@ needed to build *lmdb-tui*. Use it to track progress and priorities.
 009. [x] **mid** Unit tests for env open/list operations
 
 ### Phase 2 – CRUD & Transactions
-010. [ ] **hi** FR-03: CRUD operations inside read-write txn
-011. [ ] **mid** FR-06: transaction management commands
-012. [ ] **mid** FR-11: undo/redo stack
-013. [ ] **mid** DB service layer (`db::*` modules)
-014. [ ] **mid** Integration tests covering CRUD flows
+010. [x] **hi** FR-03: CRUD operations inside read-write txn
+011. [x] **mid** FR-06: transaction management commands
+012. [x] **mid** FR-11: undo/redo stack
+013. [x] **mid** DB service layer (`db::*` modules)
+014. [x] **mid** Integration tests covering CRUD flows
 
 ### Phase 3 – Query Engine
 015. [ ] **mid** FR-05: rich query modes (prefix, range, regex, JSONPath)
@@ -64,7 +64,7 @@ needed to build *lmdb-tui*. Use it to track progress and priorities.
 034. [~] **hi** `app` main loop and state reducer
 035. [~] **hi** `ui` layouts and widgets using ratatui
 036. [x] **hi** `db::env` open/close env and query stats
-037. [ ] **hi** `db::txn` safe wrapper over heed txns
+037. [x] **hi** `db::txn` safe wrapper over heed txns
 038. [ ] **mid** `db::query` searching and decoding
 039. [ ] **mid** `commands` CRUD, export/import, undo stack
 040. [ ] **mid** `jobs` async workers and channels

--- a/src/db/kv.rs
+++ b/src/db/kv.rs
@@ -1,0 +1,33 @@
+use anyhow::{anyhow, Result};
+use heed::{
+    types::{Bytes, Str},
+    Database, Env,
+};
+
+use super::txn::Txn;
+
+/// Put a key/value pair into the database.
+pub fn put(env: &Env, txn: &mut Txn<'_>, db_name: &str, key: &str, value: &[u8]) -> Result<()> {
+    let db: Database<Str, Bytes> = env
+        .open_database(txn.inner_mut(), Some(db_name))?
+        .ok_or_else(|| anyhow!("database not found"))?;
+    db.put(txn.inner_mut(), key, value)?;
+    Ok(())
+}
+
+/// Get a key from the database.
+pub fn get(env: &Env, txn: &Txn<'_>, db_name: &str, key: &str) -> Result<Option<Vec<u8>>> {
+    let db: Database<Str, Bytes> = env
+        .open_database(txn.inner(), Some(db_name))?
+        .ok_or_else(|| anyhow!("database not found"))?;
+    Ok(db.get(txn.inner(), key)?.map(|v| v.to_vec()))
+}
+
+/// Delete a key from the database.
+pub fn delete(env: &Env, txn: &mut Txn<'_>, db_name: &str, key: &str) -> Result<()> {
+    let db: Database<Str, Bytes> = env
+        .open_database(txn.inner_mut(), Some(db_name))?
+        .ok_or_else(|| anyhow!("database not found"))?;
+    db.delete(txn.inner_mut(), key)?;
+    Ok(())
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,1 +1,4 @@
 pub mod env;
+pub mod kv;
+pub mod txn;
+pub mod undo;

--- a/src/db/txn.rs
+++ b/src/db/txn.rs
@@ -1,0 +1,34 @@
+use anyhow::Result;
+use heed::{Env, RwTxn};
+
+/// Wrapper around `heed::RwTxn` with simpler lifetime management.
+pub struct Txn<'env> {
+    inner: RwTxn<'env>,
+}
+
+impl<'env> Txn<'env> {
+    /// Begin a new read-write transaction.
+    pub fn begin(env: &'env Env) -> Result<Self> {
+        let inner = env.write_txn()?;
+        Ok(Self { inner })
+    }
+
+    /// Commit the transaction.
+    pub fn commit(self) -> Result<()> {
+        self.inner.commit()?;
+        Ok(())
+    }
+
+    /// Abort the transaction.
+    pub fn abort(self) {
+        self.inner.abort();
+    }
+
+    pub(crate) fn inner(&self) -> &RwTxn<'env> {
+        &self.inner
+    }
+
+    pub(crate) fn inner_mut(&mut self) -> &mut RwTxn<'env> {
+        &mut self.inner
+    }
+}

--- a/src/db/undo.rs
+++ b/src/db/undo.rs
@@ -1,0 +1,83 @@
+use anyhow::Result;
+
+use heed::Env;
+
+use super::{kv, txn::Txn};
+
+/// Represents a CRUD operation for undo/redo.
+#[derive(Clone)]
+pub enum Op {
+    Put {
+        db: String,
+        key: String,
+        prev: Option<Vec<u8>>,
+        new: Vec<u8>,
+    },
+    Delete {
+        db: String,
+        key: String,
+        prev: Option<Vec<u8>>,
+    },
+}
+
+/// Simple undo/redo stack.
+pub struct UndoStack {
+    ops: Vec<Op>,
+    pos: usize,
+}
+
+impl UndoStack {
+    pub fn new() -> Self {
+        Self {
+            ops: Vec::new(),
+            pos: 0,
+        }
+    }
+
+    pub fn push(&mut self, op: Op) {
+        if self.pos < self.ops.len() {
+            self.ops.truncate(self.pos);
+        }
+        self.ops.push(op);
+        self.pos = self.ops.len();
+    }
+
+    pub fn undo(&mut self, env: &Env, txn: &mut Txn<'_>) -> Result<bool> {
+        if self.pos == 0 {
+            return Ok(false);
+        }
+        self.pos -= 1;
+        let op = self.ops[self.pos].clone();
+        match op {
+            Op::Put { db, key, prev, .. } => match prev {
+                Some(v) => kv::put(env, txn, &db, &key, &v)?,
+                None => kv::delete(env, txn, &db, &key)?,
+            },
+            Op::Delete { db, key, prev } => {
+                if let Some(v) = prev {
+                    kv::put(env, txn, &db, &key, &v)?;
+                }
+            }
+        }
+        Ok(true)
+    }
+
+    pub fn redo(&mut self, env: &Env, txn: &mut Txn<'_>) -> Result<bool> {
+        if self.pos == self.ops.len() {
+            return Ok(false);
+        }
+        let op = self.ops[self.pos].clone();
+        self.pos += 1;
+        match op {
+            Op::Put { db, key, new, .. } => kv::put(env, txn, &db, &key, &new)?,
+            Op::Delete { db, key, .. } => kv::delete(env, txn, &db, &key)?,
+        }
+        Ok(true)
+    }
+}
+
+impl Default for UndoStack {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/tests/crud.rs
+++ b/tests/crud.rs
@@ -1,0 +1,102 @@
+use heed::types::{Bytes, Str};
+use lmdb_tui::db::{
+    env::open_env,
+    kv,
+    txn::Txn,
+    undo::{Op, UndoStack},
+};
+use tempfile::tempdir;
+
+#[test]
+fn put_get_delete_commit() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let env = open_env(dir.path(), false)?;
+
+    // create db "data"
+    let mut tx = env.write_txn()?;
+    env.create_database::<Str, Bytes>(&mut tx, Some("data"))?;
+    tx.commit()?;
+
+    let mut txn = Txn::begin(&env)?;
+    kv::put(&env, &mut txn, "data", "foo", b"bar")?;
+    assert_eq!(kv::get(&env, &txn, "data", "foo")?, Some(b"bar".to_vec()));
+    kv::delete(&env, &mut txn, "data", "foo")?;
+    assert_eq!(kv::get(&env, &txn, "data", "foo")?, None);
+    kv::put(&env, &mut txn, "data", "foo", b"baz")?;
+    txn.commit()?;
+
+    // verify persisted
+    let rtxn = env.read_txn()?;
+    let db = env
+        .open_database::<Str, Bytes>(&rtxn, Some("data"))?
+        .unwrap();
+    assert_eq!(
+        db.get(&rtxn, "foo")?.map(|v| v.to_vec()),
+        Some(b"baz".to_vec())
+    );
+    Ok(())
+}
+
+#[test]
+fn txn_abort_discards_changes() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let env = open_env(dir.path(), false)?;
+
+    let mut tx = env.write_txn()?;
+    env.create_database::<Str, Bytes>(&mut tx, Some("data"))?;
+    tx.commit()?;
+
+    let mut txn = Txn::begin(&env)?;
+    kv::put(&env, &mut txn, "data", "foo", b"bar")?;
+    txn.abort();
+
+    let rtxn = env.read_txn()?;
+    let db = env
+        .open_database::<Str, Bytes>(&rtxn, Some("data"))?
+        .unwrap();
+    assert_eq!(db.get(&rtxn, "foo")?, None);
+    Ok(())
+}
+
+#[test]
+fn undo_redo_works() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let env = open_env(dir.path(), false)?;
+
+    let mut tx = env.write_txn()?;
+    env.create_database::<Str, Bytes>(&mut tx, Some("data"))?;
+    tx.commit()?;
+
+    let mut undo = UndoStack::new();
+    let mut txn = Txn::begin(&env)?;
+    kv::put(&env, &mut txn, "data", "foo", b"bar")?;
+    undo.push(Op::Put {
+        db: "data".into(),
+        key: "foo".into(),
+        prev: None,
+        new: b"bar".to_vec(),
+    });
+    kv::put(&env, &mut txn, "data", "foo", b"baz")?;
+    undo.push(Op::Put {
+        db: "data".into(),
+        key: "foo".into(),
+        prev: Some(b"bar".to_vec()),
+        new: b"baz".to_vec(),
+    });
+
+    undo.undo(&env, &mut txn)?;
+    assert_eq!(kv::get(&env, &txn, "data", "foo")?, Some(b"bar".to_vec()));
+    undo.redo(&env, &mut txn)?;
+    assert_eq!(kv::get(&env, &txn, "data", "foo")?, Some(b"baz".to_vec()));
+
+    txn.commit()?;
+    let rtxn = env.read_txn()?;
+    let db = env
+        .open_database::<Str, Bytes>(&rtxn, Some("data"))?
+        .unwrap();
+    assert_eq!(
+        db.get(&rtxn, "foo")?.map(|v| v.to_vec()),
+        Some(b"baz".to_vec())
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add `db::txn` wrapper for read-write transactions
- add `db::kv` CRUD helpers
- add `db::undo` stack for undo/redo support
- integration tests for CRUD flows
- mark Phase 2 tasks complete in Todo

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6841fc2bc7048320aa9ce6fc37d5f8c7