### PR TITLE
Add llms.txt generation workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,30 @@
+name: Docs
+
+on:
+  push:
+    paths:
+      - 'docs/**'
+      - 'scripts/generate_llms_txt.py'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install MkDocs
+        run: pip install mkdocs mkdocs-material
+      - name: Generate llms.txt
+        run: python scripts/generate_llms_txt.py
+      - name: Build site
+        run: mkdocs build --strict
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: site
+          path: site

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,16 @@
+# lmdb-tui
+
+> Quick links for the lmdb-tui project.
+
+## Documentation
+- [README](README.md)
+- [getting-started](getting-started.md)
+- [index](index.md)
+
+## Repository
+- [README](../README.md)
+- [SPECS](../SPECS.md)
+- [CONTRIBUTING](../CONTRIBUTING.md)
+
+## Optional
+- [Todo](../Todo.md)

--- a/scripts/generate_llms_txt.py
+++ b/scripts/generate_llms_txt.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Generate docs/llms.txt from Markdown sources."""
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+
+pages = [p for p in DOCS.glob("*.md") if p.name != "llms.txt"]
+
+lines = [
+    "# lmdb-tui",
+    "",
+    "> Quick links for the lmdb-tui project.",
+    "",
+    "## Documentation",
+]
+
+for p in sorted(pages):
+    lines.append(f"- [{p.stem}]({p.name})")
+
+lines += [
+    "",
+    "## Repository",
+    f"- [README](../README.md)",
+    f"- [SPECS](../SPECS.md)",
+    f"- [CONTRIBUTING](../CONTRIBUTING.md)",
+    "",
+    "## Optional",
+    f"- [Todo](../Todo.md)",
+]
+
+(DOCS / "llms.txt").write_text("\n".join(lines) + "\n")
+print("llms.txt generated")


### PR DESCRIPTION
## Summary
- add script to build `llms.txt` from docs
- create workflow to run the script and build the docs
- include generated `docs/llms.txt`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --verbose`


------
https://chatgpt.com/codex/tasks/task_e_68420019c4548320971f1fc95023920f