### PR TITLE
Implement Phase 3 – Query Engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,6 +554,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,6 +592,17 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jsonpath_lib"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaa63191d68230cccb81c5aa23abd53ed64d83337cacbb25a7b8c7979523774f"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "libc"
@@ -621,8 +642,12 @@ dependencies = [
  "clap",
  "crossterm",
  "heed",
+ "jsonpath_lib",
  "predicates",
  "ratatui",
+ "regex",
+ "serde",
+ "serde_json",
  "tempfile",
  "tokio",
 ]
@@ -1007,6 +1032,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ ratatui = "0.26"
 heed = "0.20"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 anyhow = "1"
+regex = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+jsonpath_lib = "0.3"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/Todo.md
+++ b/Todo.md
@@ -32,9 +32,9 @@ needed to build *lmdb-tui*. Use it to track progress and priorities.
 014. [x] **mid** Integration tests covering CRUD flows
 
 ### Phase 3 – Query Engine
-015. [ ] **mid** FR-05: rich query modes (prefix, range, regex, JSONPath)
-016. [ ] **mid** Implement `db::query` module with decoders
-017. [ ] **mid** Snapshot tests for query UI
+015. [x] **mid** FR-05: rich query modes (prefix, range, regex, JSONPath)
+016. [x] **mid** Implement `db::query` module with decoders
+017. [x] **mid** Snapshot tests for query UI
 
 ### Phase 4 – Visuals and Stats
 018. [ ] **mid** FR-07: environment and DB statistics panes

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,4 +1,5 @@
 pub mod env;
 pub mod kv;
+pub mod query;
 pub mod txn;
 pub mod undo;

--- a/src/db/query.rs
+++ b/src/db/query.rs
@@ -1,0 +1,53 @@
+use anyhow::{anyhow, Result};
+use heed::{
+    types::{Bytes, Str},
+    Database, Env,
+};
+use jsonpath_lib as jsonpath;
+use regex::Regex;
+use serde_json::Value;
+
+pub enum Mode<'a> {
+    Prefix(&'a str),
+    Range(&'a str, &'a str),
+    Regex(Regex),
+    JsonPath(&'a str),
+}
+
+pub fn scan(
+    env: &Env,
+    db_name: &str,
+    mode: Mode<'_>,
+    limit: usize,
+) -> Result<Vec<(String, Vec<u8>)>> {
+    let rtxn = env.read_txn()?;
+    let db: Database<Str, Bytes> = env
+        .open_database(&rtxn, Some(db_name))?
+        .ok_or_else(|| anyhow!("database not found"))?;
+    let iter = db.iter(&rtxn)?;
+    let mut items = Vec::new();
+    for result in iter {
+        let (key, value) = result?;
+        let mut matched = false;
+        match &mode {
+            Mode::Prefix(pre) => matched = key.starts_with(*pre),
+            Mode::Range(start, end) => matched = key >= *start && key < *end,
+            Mode::Regex(re) => matched = re.is_match(key),
+            Mode::JsonPath(path) => {
+                if let Ok(v) = serde_json::from_slice::<Value>(value) {
+                    matched = jsonpath::select(&v, path)
+                        .map(|r| !r.is_empty())
+                        .unwrap_or(false);
+                }
+            }
+        }
+        if matched {
+            items.push((key.to_string(), value.to_vec()));
+            if items.len() >= limit {
+                break;
+            }
+        }
+    }
+    rtxn.commit()?;
+    Ok(items)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod app;
 pub mod db;
+pub mod ui;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,0 +1,1 @@
+pub mod query;

--- a/src/ui/query.rs
+++ b/src/ui/query.rs
@@ -1,0 +1,21 @@
+use ratatui::{
+    prelude::{Constraint, Direction, Frame, Layout, Rect},
+    widgets::{Block, Borders, List, ListItem, Paragraph},
+};
+pub fn render(f: &mut Frame, area: Rect, query: &str, entries: &[(String, Vec<u8>)]) {
+    let block = Block::default().borders(Borders::ALL).title("Query");
+    f.render_widget(block.clone(), area);
+    let inner = block.inner(area);
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Min(0)])
+        .split(inner);
+    let p = Paragraph::new(format!("Query: {query}"));
+    f.render_widget(p, chunks[0]);
+    let items: Vec<ListItem> = entries
+        .iter()
+        .map(|(k, v)| ListItem::new(format!("{}: {}", k, String::from_utf8_lossy(v))))
+        .collect();
+    let list = List::new(items);
+    f.render_widget(list, chunks[1]);
+}

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -1,0 +1,75 @@
+use heed::types::{Bytes, Str};
+use lmdb_tui::db::{
+    env::open_env,
+    query::{self, Mode},
+};
+use regex::Regex;
+use tempfile::tempdir;
+
+#[test]
+fn prefix_scan_returns_matching_keys() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let env = open_env(dir.path(), false)?;
+    let mut tx = env.write_txn()?;
+    let db = env.create_database::<Str, Str>(&mut tx, Some("data"))?;
+    db.put(&mut tx, "apple", "1")?;
+    db.put(&mut tx, "banana", "2")?;
+    db.put(&mut tx, "apricot", "3")?;
+    tx.commit()?;
+
+    let items = query::scan(&env, "data", Mode::Prefix("ap"), 10)?;
+    let keys: Vec<String> = items.iter().map(|(k, _)| k.clone()).collect();
+    assert_eq!(keys, vec!["apple", "apricot"]);
+    Ok(())
+}
+
+#[test]
+fn range_scan_filters_keys() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let env = open_env(dir.path(), false)?;
+    let mut tx = env.write_txn()?;
+    let db = env.create_database::<Str, Str>(&mut tx, Some("data"))?;
+    db.put(&mut tx, "a", "1")?;
+    db.put(&mut tx, "b", "2")?;
+    db.put(&mut tx, "c", "3")?;
+    tx.commit()?;
+
+    let items = query::scan(&env, "data", Mode::Range("a", "c"), 10)?;
+    let keys: Vec<String> = items.iter().map(|(k, _)| k.clone()).collect();
+    assert_eq!(keys, vec!["a", "b"]);
+    Ok(())
+}
+
+#[test]
+fn regex_scan_filters_keys() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let env = open_env(dir.path(), false)?;
+    let mut tx = env.write_txn()?;
+    let db = env.create_database::<Str, Str>(&mut tx, Some("data"))?;
+    db.put(&mut tx, "foo1", "1")?;
+    db.put(&mut tx, "bar", "2")?;
+    db.put(&mut tx, "foo2", "3")?;
+    tx.commit()?;
+
+    let re = Regex::new(r"^foo[0-9]")?;
+    let items = query::scan(&env, "data", Mode::Regex(re), 10)?;
+    let keys: Vec<String> = items.iter().map(|(k, _)| k.clone()).collect();
+    assert_eq!(keys, vec!["foo1", "foo2"]);
+    Ok(())
+}
+
+#[test]
+fn jsonpath_filters_values() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let env = open_env(dir.path(), false)?;
+    let mut tx = env.write_txn()?;
+    let db = env.create_database::<Str, Bytes>(&mut tx, Some("data"))?;
+    db.put(&mut tx, "1", br#"{"name":"foo"}"#)?;
+    db.put(&mut tx, "2", br#"{"name":"bar"}"#)?;
+    tx.commit()?;
+
+    let items = query::scan(&env, "data", Mode::JsonPath("$[?(@.name=='foo')]"), 10)?;
+    let keys: Vec<String> = items.iter().map(|(k, _)| k.clone()).collect();
+    assert_eq!(keys, vec!["1"]);
+    Ok(())
+}

--- a/tests/query_ui.rs
+++ b/tests/query_ui.rs
@@ -1,0 +1,20 @@
+use lmdb_tui::ui::query;
+use ratatui::{backend::TestBackend, Terminal};
+
+#[test]
+fn query_view_snapshot() -> anyhow::Result<()> {
+    let backend = TestBackend::new(20, 4);
+    let mut terminal = Terminal::new(backend)?;
+    let entries = vec![("foo".to_string(), b"bar".to_vec())];
+    terminal.draw(|f| {
+        let size = f.size();
+        query::render(f, size, "prefix f", &entries);
+    })?;
+    terminal.backend().assert_buffer_lines([
+        "┌Query─────────────┐",
+        "│Query: prefix f   │",
+        "│foo: bar          │",
+        "└──────────────────┘",
+    ]);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- implement query scanning with prefix, range, regex and JSONPath
- expose new query module and UI renderer
- add snapshot test for query UI
- cover query functions with unit tests
- mark Phase 3 tasks as complete in Todo

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6841fe433c5c8320a934b40dabd4f20a