### PR TITLE
Add llms.txt generation workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,30 @@
+name: Docs
+
+on:
+  push:
+    paths:
+      - 'docs/**'
+      - 'scripts/generate_llms_txt.py'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install MkDocs
+        run: pip install mkdocs mkdocs-material
+      - name: Generate llms.txt
+        run: python scripts/generate_llms_txt.py
+      - name: Build site
+        run: mkdocs build --strict
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: site
+          path: site

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ lmdb-tui --version
 ## Documentation
 
 Read the full documentation at <https://lmdb.nibzard.com>.
+For tools that consume our documentation automatically, see
+[llms.txt](https://lmdb.nibzard.com/llms.txt) for a brief index.
 
 ## Contributing
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,16 @@
+# lmdb-tui
+
+> Quick links for the lmdb-tui project.
+
+## Documentation
+- [README](README.md)
+- [getting-started](getting-started.md)
+- [index](index.md)
+
+## Repository
+- [README](../README.md)
+- [SPECS](../SPECS.md)
+- [CONTRIBUTING](../CONTRIBUTING.md)
+
+## Optional
+- [Todo](../Todo.md)

--- a/scripts/generate_llms_txt.py
+++ b/scripts/generate_llms_txt.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Generate docs/llms.txt from Markdown sources."""
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+
+pages = [p for p in DOCS.glob("*.md") if p.name != "llms.txt"]
+
+lines = [
+    "# lmdb-tui",
+    "",
+    "> Quick links for the lmdb-tui project.",
+    "",
+    "## Documentation",
+]
+
+for p in sorted(pages):
+    lines.append(f"- [{p.stem}]({p.name})")
+
+lines += [
+    "",
+    "## Repository",
+    f"- [README](../README.md)",
+    f"- [SPECS](../SPECS.md)",
+    f"- [CONTRIBUTING](../CONTRIBUTING.md)",
+    "",
+    "## Optional",
+    f"- [Todo](../Todo.md)",
+]
+
+(DOCS / "llms.txt").write_text("\n".join(lines) + "\n")
+print("llms.txt generated")


### PR DESCRIPTION
## Summary
- add script to build `llms.txt` from docs
- create workflow to run the script and build the docs
- include generated `docs/llms.txt`
- fix workflow by pinning `upload-artifact` action
- link to the file from the README

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --verbose`
- `mkdocs build -d /tmp/mksite`


------
https://chatgpt.com/codex/tasks/task_e_68420019c4548320971f1fc95023920f