### PR TITLE
Finish app reducer and UI layout

### DIFF
--- a/Todo.md
+++ b/Todo.md
@@ -21,7 +21,7 @@ needed to build *lmdb-tui*. Use it to track progress and priorities.
 005. [x] **hi** FR-01: open existing LMDB environment and list databases
 006. [x] **hi** FR-02: display keys and values in scrollable list
 007. [x] **mid** FR-04: support read-only sessions
-008. [~] **mid** App state reducer and navigation stack
+008. [x] **mid** App state reducer and navigation stack
 009. [x] **mid** Unit tests for env open/list operations
 
 ### Phase 2 – CRUD & Transactions
@@ -61,8 +61,8 @@ needed to build *lmdb-tui*. Use it to track progress and priorities.
 033. [ ] **lo** plugin API for custom decoders
 
 ## Module Implementation
-034. [~] **hi** `app` main loop and state reducer
-035. [~] **hi** `ui` layouts and widgets using ratatui
+034. [x] **hi** `app` main loop and state reducer
+035. [x] **hi** `ui` layouts and widgets using ratatui
 036. [x] **hi** `db::env` open/close env and query stats
 037. [x] **hi** `db::txn` safe wrapper over heed txns
 038. [ ] **mid** `db::query` searching and decoding

--- a/src/ui/db_view.rs
+++ b/src/ui/db_view.rs
@@ -1,0 +1,46 @@
+use ratatui::{
+    prelude::{Constraint, Direction, Frame, Layout, Rect},
+    style::{Modifier, Style},
+    text::Span,
+    widgets::{Block, Borders, List, ListItem},
+};
+
+/// Render the main database view.
+pub fn render(
+    f: &mut Frame,
+    area: Rect,
+    db_names: &[String],
+    selected: usize,
+    entries: &[(String, Vec<u8>)],
+) {
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(30), Constraint::Percentage(70)])
+        .split(area);
+
+    let items: Vec<ListItem> = db_names
+        .iter()
+        .enumerate()
+        .map(|(i, name)| {
+            let content = if i == selected {
+                Span::styled(
+                    name.clone(),
+                    Style::default().add_modifier(Modifier::REVERSED),
+                )
+            } else {
+                Span::raw(name.clone())
+            };
+            ListItem::new(content)
+        })
+        .collect();
+    let list = List::new(items).block(Block::default().borders(Borders::ALL).title("Databases"));
+    f.render_widget(list, chunks[0]);
+
+    let kv_items: Vec<ListItem> = entries
+        .iter()
+        .map(|(k, v)| ListItem::new(format!("{}: {}", k, String::from_utf8_lossy(v))))
+        .collect();
+    let kv_list =
+        List::new(kv_items).block(Block::default().borders(Borders::ALL).title("Entries"));
+    f.render_widget(kv_list, chunks[1]);
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,1 +1,15 @@
+pub mod db_view;
 pub mod query;
+
+use ratatui::prelude::Frame;
+
+use crate::app::{App, View};
+
+/// Render the application based on the current [`View`].
+pub fn render(f: &mut Frame, app: &App) {
+    let area = f.size();
+    match app.current_view() {
+        View::Main => db_view::render(f, area, &app.db_names, app.selected, &app.entries),
+        View::Query => query::render(f, area, &app.query, &app.entries),
+    }
+}

--- a/tests/app.rs
+++ b/tests/app.rs
@@ -1,0 +1,30 @@
+use heed::types::{Bytes, Str};
+use lmdb_tui::{
+    app::{Action, App},
+    db::env::{list_databases, open_env},
+};
+use tempfile::tempdir;
+
+#[test]
+fn reducer_switches_databases() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let env = open_env(dir.path(), false)?;
+    let mut wtxn = env.write_txn()?;
+    let db1 = env.create_database::<Str, Str>(&mut wtxn, Some("first"))?;
+    db1.put(&mut wtxn, "k1", "v1")?;
+    let db2 = env.create_database::<Str, Bytes>(&mut wtxn, Some("second"))?;
+    db2.put(&mut wtxn, "k2", b"v2")?;
+    wtxn.commit()?;
+
+    let names = list_databases(&env)?;
+    let mut app = App::new(env, names)?;
+    assert_eq!(app.selected, 0);
+    assert_eq!(app.entries.len(), 1);
+    assert_eq!(app.entries[0].0, "k1");
+
+    app.reduce(Action::NextDb)?;
+    assert_eq!(app.selected, 1);
+    assert_eq!(app.entries.len(), 1);
+    assert_eq!(app.entries[0].0, "k2");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- implement app state reducer with navigation stack
- integrate reducer into main loop
- add database view widget and rendering logic
- add unit test for reducer
- mark related tasks complete in Todo

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68420855d20883208cbbe9eba73d50d0