### PR TITLE
Implement export/import utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b094a32014c3d1f3944e4808e0e7c70e97dae0660886a8eb6dbc52d745badc"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +256,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width 0.2.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +309,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +366,12 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -564,6 +610,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width 0.2.0",
+ "web-time",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,6 +651,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "jsonpath_lib"
@@ -641,7 +710,9 @@ dependencies = [
  "assert_cmd",
  "clap",
  "crossterm",
+ "csv",
  "heed",
+ "indicatif",
  "jsonpath_lib",
  "predicates",
  "ratatui",
@@ -718,6 +789,12 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -834,6 +911,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,7 +1011,7 @@ dependencies = [
  "strum",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1239,7 +1322,7 @@ checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
  "itertools 0.13.0",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1247,6 +1330,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "url"
@@ -1293,6 +1382,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 jsonpath_lib = "0.3"
+csv = "1"
+indicatif = "0.17"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/db/io.rs
+++ b/src/db/io.rs
@@ -1,0 +1,114 @@
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::Path;
+
+use anyhow::{anyhow, Result};
+use csv::Writer;
+use heed::{
+    types::{Bytes, Str},
+    Database, Env,
+};
+use indicatif::ProgressBar;
+use serde::{Deserialize, Serialize};
+use serde_json::{self, Value};
+
+use crate::db::txn::Txn;
+
+#[derive(Serialize, Deserialize)]
+struct Record {
+    key: String,
+    value: Value,
+}
+
+pub fn export_json(env: &Env, db_name: &str, path: &Path) -> Result<()> {
+    let rtxn = env.read_txn()?;
+    let db: Database<Str, Bytes> = env
+        .open_database(&rtxn, Some(db_name))?
+        .ok_or_else(|| anyhow!("database not found"))?;
+    let stats = db.stat(&rtxn)?;
+    let pb = ProgressBar::new(stats.entries as u64);
+    let file = File::create(path)?;
+    let mut writer = BufWriter::new(file);
+    write!(writer, "[")?;
+    let mut first = true;
+    for result in db.iter(&rtxn)? {
+        let (key, value) = result?;
+        let json: Value = serde_json::from_slice(value)?;
+        let rec = Record {
+            key: key.to_string(),
+            value: json,
+        };
+        if !first {
+            write!(writer, ",")?;
+        }
+        serde_json::to_writer(&mut writer, &rec)?;
+        first = false;
+        pb.inc(1);
+    }
+    write!(writer, "]")?;
+    writer.flush()?;
+    pb.finish();
+    rtxn.commit()?;
+    Ok(())
+}
+
+pub fn export_csv(env: &Env, db_name: &str, path: &Path) -> Result<()> {
+    let rtxn = env.read_txn()?;
+    let db: Database<Str, Bytes> = env
+        .open_database(&rtxn, Some(db_name))?
+        .ok_or_else(|| anyhow!("database not found"))?;
+    let stats = db.stat(&rtxn)?;
+    let pb = ProgressBar::new(stats.entries as u64);
+    let file = File::create(path)?;
+    let mut wtr = Writer::from_writer(file);
+    for result in db.iter(&rtxn)? {
+        let (key, value) = result?;
+        wtr.write_record([key, &String::from_utf8_lossy(value)])?;
+        pb.inc(1);
+    }
+    wtr.flush()?;
+    pb.finish();
+    rtxn.commit()?;
+    Ok(())
+}
+
+pub fn import_json(env: &Env, db_name: &str, path: &Path) -> Result<usize> {
+    let mut txn = Txn::begin(env)?;
+    let db: Database<Str, Bytes> = env
+        .open_database(txn.inner_mut(), Some(db_name))?
+        .ok_or_else(|| anyhow!("database not found"))?;
+    let file = File::open(path)?;
+    let records: Vec<Record> = serde_json::from_reader(file)?;
+    let pb = ProgressBar::new(records.len() as u64);
+    for rec in &records {
+        let bytes = serde_json::to_vec(&rec.value)?;
+        db.put(txn.inner_mut(), &rec.key, &bytes)?;
+        pb.inc(1);
+    }
+    pb.finish();
+    txn.commit()?;
+    Ok(records.len())
+}
+
+pub fn import_csv(env: &Env, db_name: &str, path: &Path) -> Result<usize> {
+    let mut txn = Txn::begin(env)?;
+    let db: Database<Str, Bytes> = env
+        .open_database(txn.inner_mut(), Some(db_name))?
+        .ok_or_else(|| anyhow!("database not found"))?;
+    let mut rdr = csv::ReaderBuilder::new()
+        .has_headers(false)
+        .from_path(path)?;
+    let pb = ProgressBar::new_spinner();
+    let mut count = 0usize;
+    for result in rdr.records() {
+        let rec = result?;
+        let key = rec.get(0).ok_or_else(|| anyhow!("missing key"))?;
+        let value = rec.get(1).unwrap_or("");
+        db.put(txn.inner_mut(), key, value.as_bytes())?;
+        count += 1;
+        pb.inc(1);
+    }
+    pb.finish();
+    txn.commit()?;
+    Ok(count)
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,4 +1,5 @@
 pub mod env;
+pub mod io;
 pub mod kv;
 pub mod query;
 pub mod txn;

--- a/tests/export.rs
+++ b/tests/export.rs
@@ -1,0 +1,57 @@
+use heed::types::{Bytes, Str};
+use lmdb_tui::db::{env::list_entries, env::open_env, io};
+use tempfile::tempdir;
+
+#[test]
+fn export_import_json_roundtrip() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let env = open_env(dir.path(), false)?;
+    let mut tx = env.write_txn()?;
+    let db = env.create_database::<Str, Bytes>(&mut tx, Some("data"))?;
+    db.put(&mut tx, "a", br#"{"n":1}"#)?;
+    db.put(&mut tx, "b", br#"{"n":2}"#)?;
+    tx.commit()?;
+    let path = dir.path().join("out.json");
+    io::export_json(&env, "data", &path)?;
+    let mut tx = env.write_txn()?;
+    db.clear(&mut tx)?;
+    tx.commit()?;
+    io::import_json(&env, "data", &path)?;
+    let entries = list_entries(&env, "data", 10)?;
+    let keys: Vec<String> = entries.iter().map(|(k, _)| k.clone()).collect();
+    assert_eq!(keys.len(), 2);
+    Ok(())
+}
+
+#[test]
+fn export_json_validates() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let env = open_env(dir.path(), false)?;
+    let mut tx = env.write_txn()?;
+    let db = env.create_database::<Str, Bytes>(&mut tx, Some("data"))?;
+    db.put(&mut tx, "a", b"not json")?;
+    tx.commit()?;
+    let path = dir.path().join("bad.json");
+    assert!(io::export_json(&env, "data", &path).is_err());
+    Ok(())
+}
+
+#[test]
+fn export_import_csv_roundtrip() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let env = open_env(dir.path(), false)?;
+    let mut tx = env.write_txn()?;
+    let db = env.create_database::<Str, Str>(&mut tx, Some("data"))?;
+    db.put(&mut tx, "x", "1")?;
+    db.put(&mut tx, "y", "2")?;
+    tx.commit()?;
+    let path = dir.path().join("out.csv");
+    io::export_csv(&env, "data", &path)?;
+    let mut tx = env.write_txn()?;
+    db.clear(&mut tx)?;
+    tx.commit()?;
+    io::import_csv(&env, "data", &path)?;
+    let entries = list_entries(&env, "data", 10)?;
+    assert_eq!(entries.len(), 2);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- implement JSON/CSV export and import helpers
- show progress bars with indicatif
- verify JSON validity before exporting
- test import/export flows

## Testing
- `cargo clippy --all-targets --all-features -q`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68420928ad108320a9b0e40fa1652eb9