### PR TITLE
Implement commands module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +293,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "csv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -639,8 +666,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "base64",
  "clap",
  "crossterm",
+ "csv",
  "heed",
  "jsonpath_lib",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 jsonpath_lib = "0.3"
+base64 = "0.21"
+csv = "1"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,0 +1,139 @@
+use std::io::{Read, Write};
+
+use anyhow::{anyhow, Result};
+use base64::{engine::general_purpose, Engine as _};
+use heed::Env;
+use serde::{Deserialize, Serialize};
+
+use crate::db::{
+    env as dbenv, kv,
+    txn::Txn,
+    undo::{Op, UndoStack},
+};
+
+/// Put a key/value pair into the database and record undo information.
+pub fn put(
+    env: &Env,
+    txn: &mut Txn<'_>,
+    undo: &mut UndoStack,
+    db: &str,
+    key: &str,
+    value: &[u8],
+) -> Result<()> {
+    let prev = kv::get(env, txn, db, key)?;
+    kv::put(env, txn, db, key, value)?;
+    undo.push(Op::Put {
+        db: db.to_string(),
+        key: key.to_string(),
+        prev,
+        new: value.to_vec(),
+    });
+    Ok(())
+}
+
+/// Get a key from the database.
+pub fn get(env: &Env, txn: &Txn<'_>, db: &str, key: &str) -> Result<Option<Vec<u8>>> {
+    kv::get(env, txn, db, key)
+}
+
+/// Delete a key from the database and record undo information.
+pub fn delete(
+    env: &Env,
+    txn: &mut Txn<'_>,
+    undo: &mut UndoStack,
+    db: &str,
+    key: &str,
+) -> Result<()> {
+    let prev = kv::get(env, txn, db, key)?;
+    kv::delete(env, txn, db, key)?;
+    undo.push(Op::Delete {
+        db: db.to_string(),
+        key: key.to_string(),
+        prev,
+    });
+    Ok(())
+}
+
+#[derive(Serialize, Deserialize)]
+struct ExportItem {
+    key: String,
+    value: String,
+}
+
+/// Export the entire database to JSON.
+pub fn export_json<W: Write>(env: &Env, db_name: &str, mut writer: W) -> Result<()> {
+    let entries = dbenv::list_entries(env, db_name, usize::MAX)?;
+    let items: Vec<ExportItem> = entries
+        .into_iter()
+        .map(|(k, v)| ExportItem {
+            key: k,
+            value: general_purpose::STANDARD.encode(v),
+        })
+        .collect();
+    serde_json::to_writer(&mut writer, &items)?;
+    Ok(())
+}
+
+/// Import records from JSON and record undo information.
+pub fn import_json<R: Read>(
+    env: &Env,
+    txn: &mut Txn<'_>,
+    undo: &mut UndoStack,
+    db_name: &str,
+    mut reader: R,
+) -> Result<()> {
+    let items: Vec<ExportItem> = serde_json::from_reader(&mut reader)?;
+    for item in items {
+        let value = general_purpose::STANDARD.decode(item.value)?;
+        let prev = kv::get(env, txn, db_name, &item.key)?;
+        kv::put(env, txn, db_name, &item.key, &value)?;
+        undo.push(Op::Put {
+            db: db_name.to_string(),
+            key: item.key,
+            prev,
+            new: value,
+        });
+    }
+    Ok(())
+}
+
+/// Export the database to CSV (columns: key,value with base64 value).
+pub fn export_csv<W: Write>(env: &Env, db_name: &str, writer: W) -> Result<()> {
+    let entries = dbenv::list_entries(env, db_name, usize::MAX)?;
+    let mut wtr = csv::Writer::from_writer(writer);
+    wtr.write_record(["key", "value"])?;
+    for (k, v) in entries {
+        wtr.write_record([k, general_purpose::STANDARD.encode(v)])?;
+    }
+    wtr.flush()?;
+    Ok(())
+}
+
+/// Import records from CSV and record undo information.
+pub fn import_csv<R: Read>(
+    env: &Env,
+    txn: &mut Txn<'_>,
+    undo: &mut UndoStack,
+    db_name: &str,
+    reader: R,
+) -> Result<()> {
+    let mut rdr = csv::Reader::from_reader(reader);
+    for result in rdr.records() {
+        let record = result?;
+        let key = record
+            .get(0)
+            .ok_or_else(|| anyhow!("missing key"))?
+            .to_string();
+        let value_str = record.get(1).ok_or_else(|| anyhow!("missing value"))?;
+        let value = general_purpose::STANDARD.decode(value_str)?;
+        let prev = kv::get(env, txn, db_name, &key)?;
+        kv::put(env, txn, db_name, &key, &value)?;
+        undo.push(Op::Put {
+            db: db_name.to_string(),
+            key,
+            prev,
+            new: value,
+        });
+    }
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod app;
+pub mod commands;
 pub mod db;
 pub mod ui;

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -1,0 +1,83 @@
+use heed::types::{Bytes, Str};
+use lmdb_tui::{
+    commands,
+    db::{env::open_env, txn::Txn, undo::UndoStack},
+};
+use tempfile::tempdir;
+
+#[test]
+fn crud_with_undo() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let env = open_env(dir.path(), false)?;
+    let mut tx = env.write_txn()?;
+    env.create_database::<Str, Bytes>(&mut tx, Some("data"))?;
+    tx.commit()?;
+
+    let mut undo = UndoStack::new();
+    let mut txn = Txn::begin(&env)?;
+
+    commands::put(&env, &mut txn, &mut undo, "data", "foo", b"bar")?;
+    assert_eq!(
+        commands::get(&env, &txn, "data", "foo")?,
+        Some(b"bar".to_vec())
+    );
+
+    commands::put(&env, &mut txn, &mut undo, "data", "foo", b"baz")?;
+    assert_eq!(
+        commands::get(&env, &txn, "data", "foo")?,
+        Some(b"baz".to_vec())
+    );
+
+    undo.undo(&env, &mut txn)?;
+    assert_eq!(
+        commands::get(&env, &txn, "data", "foo")?,
+        Some(b"bar".to_vec())
+    );
+    undo.redo(&env, &mut txn)?;
+    assert_eq!(
+        commands::get(&env, &txn, "data", "foo")?,
+        Some(b"baz".to_vec())
+    );
+
+    commands::delete(&env, &mut txn, &mut undo, "data", "foo")?;
+    assert_eq!(commands::get(&env, &txn, "data", "foo")?, None);
+    undo.undo(&env, &mut txn)?;
+    assert_eq!(
+        commands::get(&env, &txn, "data", "foo")?,
+        Some(b"baz".to_vec())
+    );
+
+    txn.commit()?;
+    Ok(())
+}
+
+#[test]
+fn export_import_json() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let env = open_env(dir.path(), false)?;
+    let mut tx = env.write_txn()?;
+    env.create_database::<Str, Str>(&mut tx, Some("data"))?;
+    tx.commit()?;
+
+    let mut undo = UndoStack::new();
+    let mut txn = Txn::begin(&env)?;
+    commands::put(&env, &mut txn, &mut undo, "data", "a", b"1")?;
+    commands::put(&env, &mut txn, &mut undo, "data", "b", b"2")?;
+    txn.commit()?;
+
+    let mut buf = Vec::new();
+    commands::export_json(&env, "data", &mut buf)?;
+
+    let mut txn2 = Txn::begin(&env)?;
+    let mut undo2 = UndoStack::new();
+    commands::delete(&env, &mut txn2, &mut undo2, "data", "a")?;
+    commands::delete(&env, &mut txn2, &mut undo2, "data", "b")?;
+    commands::import_json(&env, &mut txn2, &mut undo2, "data", buf.as_slice())?;
+    txn2.commit()?;
+
+    let rtxn = env.read_txn()?;
+    let db = env.open_database::<Str, Str>(&rtxn, Some("data"))?.unwrap();
+    assert_eq!(db.get(&rtxn, "a")?, Some("1"));
+    assert_eq!(db.get(&rtxn, "b")?, Some("2"));
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add new `commands` module for CRUD operations
- support JSON/CSV export and import with undo tracking
- expose commands via crate root
- add tests for command flows
- add `base64` and `csv` dependencies

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6842093a8eac832093b64aa61888c428