### PR TITLE
Introduce async jobs module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ clap = { version = "4.5", features = ["derive"] }
 crossterm = "0.27"
 ratatui = "0.26"
 heed = "0.20"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
 anyhow = "1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }

--- a/Todo.md
+++ b/Todo.md
@@ -67,7 +67,7 @@ needed to build *lmdb-tui*. Use it to track progress and priorities.
 037. [x] **hi** `db::txn` safe wrapper over heed txns
 038. [ ] **mid** `db::query` searching and decoding
 039. [ ] **mid** `commands` CRUD, export/import, undo stack
-040. [ ] **mid** `jobs` async workers and channels
+040. [x] **mid** `jobs` async workers and channels
 041. [ ] **mid** `config` load/save YAML/TOML settings
 042. [ ] **lo** `util` helpers (hex/utf-8, formatting)
 043. [ ] **mid** `errors` define `AppError` via `thiserror`

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -1,0 +1,46 @@
+use anyhow::Result;
+use tokio::sync::{mpsc, oneshot};
+
+/// Message sent to the worker containing the request and a channel to send back the response.
+struct Job<Req, Res> {
+    req: Req,
+    resp: oneshot::Sender<Res>,
+}
+
+/// Handle to a background worker processing requests asynchronously.
+pub struct Worker<Req, Res> {
+    tx: mpsc::Sender<Job<Req, Res>>,
+}
+
+impl<Req, Res> Worker<Req, Res>
+where
+    Req: Send + 'static,
+    Res: Send + 'static,
+{
+    /// Spawn a new worker. The given handler will be called for every request.
+    pub fn start<F, Fut>(buffer: usize, mut handler: F) -> Self
+    where
+        F: FnMut(Req) -> Fut + Send + 'static,
+        Fut: std::future::Future<Output = Res> + Send + 'static,
+    {
+        let (tx, mut rx) = mpsc::channel::<Job<Req, Res>>(buffer);
+        tokio::spawn(async move {
+            while let Some(Job { req, resp }) = rx.recv().await {
+                let result = handler(req).await;
+                let _ = resp.send(result);
+            }
+        });
+        Self { tx }
+    }
+
+    /// Send a request to the worker and wait for the response.
+    pub async fn request(&self, req: Req) -> Result<Res> {
+        let (tx, rx) = oneshot::channel();
+        self.tx
+            .send(Job { req, resp: tx })
+            .await
+            .map_err(|e| anyhow::anyhow!("send error: {e}"))?;
+        let res = rx.await.map_err(|e| anyhow::anyhow!("recv error: {e}"))?;
+        Ok(res)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod app;
 pub mod db;
+pub mod jobs;
 pub mod ui;

--- a/tests/jobs.rs
+++ b/tests/jobs.rs
@@ -1,0 +1,10 @@
+use lmdb_tui::jobs::Worker;
+
+#[tokio::test]
+async fn worker_processes_requests() -> anyhow::Result<()> {
+    let worker = Worker::start(1, |n: u32| async move { n * 2 });
+
+    let result = worker.request(3).await?;
+    assert_eq!(result, 6);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add new `jobs` module with async worker API
- expose `jobs` from library
- enable tokio `sync` feature
- add unit test for worker
- mark jobs task complete in Todo list

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6842094bbe0c8320bb537c32edfd1d82