### PR TITLE
Add YAML/TOML config module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,8 +648,10 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "tokio",
+ "toml",
 ]
 
 [[package]]
@@ -1040,6 +1042,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,6 +1244,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,6 +1312,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"
@@ -1455,6 +1526,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 jsonpath_lib = "0.3"
+serde_yaml = "0.9"
+toml = "0.8"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/Todo.md
+++ b/Todo.md
@@ -68,7 +68,7 @@ needed to build *lmdb-tui*. Use it to track progress and priorities.
 038. [ ] **mid** `db::query` searching and decoding
 039. [ ] **mid** `commands` CRUD, export/import, undo stack
 040. [ ] **mid** `jobs` async workers and channels
-041. [ ] **mid** `config` load/save YAML/TOML settings
+041. [x] **mid** `config` load/save YAML/TOML settings
 042. [ ] **lo** `util` helpers (hex/utf-8, formatting)
 043. [ ] **mid** `errors` define `AppError` via `thiserror`
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,34 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Default)]
+pub struct Config {
+    #[serde(default)]
+    pub keymap: BTreeMap<String, String>,
+    pub theme: Option<String>,
+}
+
+pub fn load(path: &Path) -> Result<Config> {
+    let data = std::fs::read_to_string(path)?;
+    let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("");
+    let cfg = if ext.eq_ignore_ascii_case("yaml") || ext.eq_ignore_ascii_case("yml") {
+        serde_yaml::from_str(&data)?
+    } else {
+        toml::from_str(&data)?
+    };
+    Ok(cfg)
+}
+
+pub fn save(config: &Config, path: &Path) -> Result<()> {
+    let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("");
+    let data = if ext.eq_ignore_ascii_case("yaml") || ext.eq_ignore_ascii_case("yml") {
+        serde_yaml::to_string(config)?
+    } else {
+        toml::to_string_pretty(config)?
+    };
+    std::fs::write(path, data)?;
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod app;
+pub mod config;
 pub mod db;
 pub mod ui;

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,0 +1,28 @@
+use lmdb_tui::config::{self, Config};
+use tempfile::Builder;
+
+#[test]
+fn roundtrip_toml() -> anyhow::Result<()> {
+    let cfg = Config {
+        theme: Some("dark".into()),
+        keymap: [("quit".into(), "q".into())].into_iter().collect(),
+    };
+    let file = Builder::new().suffix(".toml").tempfile()?;
+    config::save(&cfg, file.path())?;
+    let loaded = config::load(file.path())?;
+    assert_eq!(loaded, cfg);
+    Ok(())
+}
+
+#[test]
+fn roundtrip_yaml() -> anyhow::Result<()> {
+    let cfg = Config {
+        theme: Some("light".into()),
+        keymap: [("open".into(), "o".into())].into_iter().collect(),
+    };
+    let file = Builder::new().suffix(".yaml").tempfile()?;
+    config::save(&cfg, file.path())?;
+    let loaded = config::load(file.path())?;
+    assert_eq!(loaded, cfg);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- implement `config` module for reading/writing settings
- expose new module in library
- test YAML and TOML round-trips
- mark config module task complete

## Testing
- `cargo clippy --all-targets --all-features`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6842094dea688320b3c11a9e1ab6a35f