### PR TITLE
Implement AppError with thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,6 +649,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror",
  "tokio",
 ]
 
@@ -1186,6 +1187,26 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tinystr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 jsonpath_lib = "0.3"
+thiserror = "1"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/Todo.md
+++ b/Todo.md
@@ -70,7 +70,7 @@ needed to build *lmdb-tui*. Use it to track progress and priorities.
 040. [ ] **mid** `jobs` async workers and channels
 041. [ ] **mid** `config` load/save YAML/TOML settings
 042. [ ] **lo** `util` helpers (hex/utf-8, formatting)
-043. [ ] **mid** `errors` define `AppError` via `thiserror`
+043. [x] **mid** `errors` define `AppError` via `thiserror`
 
 ## Non-Functional Goals
 044. [ ] **mid** Keep RSS under 200 MB via streaming

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,17 @@
+use thiserror::Error;
+
+/// Application level errors used throughout the crate.
+#[derive(Debug, Error)]
+pub enum AppError {
+    /// Requested database does not exist in the environment.
+    #[error("database not found: {0}")]
+    DatabaseNotFound(String),
+
+    /// Wrapper around IO errors.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    /// Errors originating from the underlying LMDB library.
+    #[error(transparent)]
+    Lmdb(#[from] heed::Error),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod app;
 pub mod db;
+pub mod errors;
 pub mod ui;

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -1,0 +1,15 @@
+use lmdb_tui::errors::AppError;
+
+#[test]
+fn formats_database_not_found() {
+    let err = AppError::DatabaseNotFound("foo".into());
+    assert_eq!(format!("{err}"), "database not found: foo");
+}
+
+#[test]
+fn converts_to_anyhow_error() -> anyhow::Result<()> {
+    let err = AppError::DatabaseNotFound("bar".into());
+    let ah: anyhow::Error = err.into();
+    assert!(ah.to_string().contains("database not found: bar"));
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- create `errors` module with `AppError`
- expose `errors` module via library
- add unit tests for `AppError`
- track work in `Todo.md`
- update dependencies for `thiserror`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68420957b63c83208f03ef9010322265