### PR TITLE
Add packaging scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,23 @@ To view the current version:
 lmdb-tui --version
 ```
 
+## Packaging
+
+Release binaries can be produced with the helper scripts in `scripts/`.
+To build static artifacts for Linux, macOS and Windows targets, run:
+
+```bash
+scripts/cross_build.sh
+```
+
+Homebrew and Scoop manifests can be generated with:
+
+```bash
+python scripts/generate_manifests.py
+```
+
+The generated files are written to the `dist/` directory.
+
 ## Documentation
 
 Read the full documentation at <https://lmdb.nibzard.com>.

--- a/Todo.md
+++ b/Todo.md
@@ -50,7 +50,7 @@ needed to build *lmdb-tui*. Use it to track progress and priorities.
 ### Phase 6 – Polish & Docs
 025. [ ] **mid** FR-10: configurable keybindings and themes
 026. [ ] **lo** FR-12: embedded help screen with searchable palette
-027. [ ] **mid** Packaging scripts: cross-build, Homebrew/Scoop manifests
+027. [x] **mid** Packaging scripts: cross-build, Homebrew/Scoop manifests
 028. [ ] **mid** Usage examples and screenshots in README
 029. [ ] **mid** Document config format in `docs/`
 

--- a/scripts/cross_build.sh
+++ b/scripts/cross_build.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Build release binaries for multiple targets using cross.
+# Requires https://github.com/cross-rs/cross to be installed.
+set -euo pipefail
+
+# List of targets to build
+TARGETS=(
+  x86_64-unknown-linux-musl
+  aarch64-unknown-linux-musl
+  x86_64-apple-darwin
+  aarch64-apple-darwin
+  x86_64-pc-windows-gnu
+  aarch64-pc-windows-gnu
+)
+
+# Determine package version from Cargo.toml
+VERSION=$(grep '^version =' Cargo.toml | head -n1 | cut -d '"' -f2)
+
+for target in "${TARGETS[@]}"; do
+  echo "Building $target"
+  cross build --release --target "$target"
+  dir="target/$target/release"
+  bin="lmdb-tui"
+  [[ "$target" == *windows* ]] && bin+=".exe"
+  archive="lmdb-tui-${VERSION}-${target}.tar.gz"
+  (cd "$dir" && tar -czf "../../../${archive}" "$bin")
+  echo "Created $archive"
+
+done
+
+mkdir -p dist
+mv lmdb-tui-*.tar.gz dist/
+

--- a/scripts/generate_manifests.py
+++ b/scripts/generate_manifests.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Generate Homebrew formula and Scoop manifest."""
+
+import json
+import pathlib
+import tomllib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+def get_version() -> str:
+    data = tomllib.loads((ROOT / "Cargo.toml").read_text())
+    return data["package"]["version"]
+
+version = get_version()
+
+dist = ROOT / "dist"
+dist.mkdir(exist_ok=True)
+
+formula = f"""class LmdbTui < Formula
+  desc \"Terminal UI for LMDB databases\"
+  homepage \"https://github.com/nibzard/lmdb-tui\"
+  url \"https://github.com/nibzard/lmdb-tui/archive/v{version}.tar.gz\"
+  sha256 \"PUT_SHA256_HERE\"
+  license \"Apache-2.0\"
+
+  def install
+    bin.install \"lmdb-tui\"
+  end
+
+  test do
+    system \"#{bin}/lmdb-tui\", \"--version\"
+  end
+end
+"""
+
+(dist / "lmdb-tui.rb").write_text(formula)
+
+manifest = {
+    "version": version,
+    "description": "Terminal UI for LMDB databases",
+    "homepage": "https://github.com/nibzard/lmdb-tui",
+    "license": "Apache-2.0",
+    "bin": "lmdb-tui.exe",
+    "architecture": {
+        "64bit": {
+            "url": f"https://github.com/nibzard/lmdb-tui/releases/download/v{version}/lmdb-tui-{version}-x86_64-pc-windows-gnu.zip",
+            "hash": "TODO"
+        }
+    }
+}
+
+(dist / "lmdb-tui.json").write_text(json.dumps(manifest, indent=2) + "\n")
+
+print("Manifests generated in", dist)
+


### PR DESCRIPTION
## Summary
- add `scripts/cross_build.sh` for building release binaries with cross
- generate Homebrew formula and Scoop manifest via `scripts/generate_manifests.py`
- document packaging workflow in the README
- mark packaging task complete in `Todo.md`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6842097eae3883208420ae5cb86a47d5