### PR TITLE
Implement CLI UX improvements

### DIFF
--- a/SPECS.md
+++ b/SPECS.md
@@ -54,7 +54,7 @@ Terminal backend	crossterm	Cross-platform, WinPTY/ConPTY friendly
 TUI framework	ratatui (fork of tui-rs)	Maintained; flexible layout API
 Async tasks	tokio (multi-thread)	Only for background jobs & channels
 LMDB bindings	heed (safe zero-copy) or rkv or lmdb-rs	Evaluate benches; prefer heed for safety
-CLI parsing	clap v4 derive	Flags, subcommands (e.g., stats, open)
+CLI parsing	clap v4 derive	Flags, subcommands (e.g., stats, open); help displayed when run without args
 Serialization	serde, serde_json, serde_yaml, csv	Export/import
 Error handling	thiserror, anyhow	Rich context
 Logging	tracing, tracing-subscriber	JSON and colour log output

--- a/Todo.md
+++ b/Todo.md
@@ -79,9 +79,9 @@ needed to build *lmdb-tui*. Use it to track progress and priorities.
 047. [ ] **mid** Audit crates to ensure no network I/O
 
 ### CLI UX Guidelines
-048. [ ] **mid** Update SPECS for help output when run without args; Clap shows examples
-049. [ ] **mid** Map common errors to exit codes and add tests
-050. [ ] **mid** Implement `--plain` and `--json` output modes
-051. [ ] **mid** Honour `$DEBUG` and `$PAGER` environment variables
-052. [ ] **mid** Add `-q` quiet and `--verbose` logging flags
-053. [ ] **mid** Include README link and example commands in `--help`
+048. [x] **mid** Update SPECS for help output when run without args; Clap shows examples
+049. [x] **mid** Map common errors to exit codes and add tests
+050. [x] **mid** Implement `--plain` and `--json` output modes
+051. [x] **mid** Honour `$DEBUG` and `$PAGER` environment variables
+052. [x] **mid** Add `-q` quiet and `--verbose` logging flags
+053. [x] **mid** Include README link and example commands in `--help`

--- a/src/app.rs
+++ b/src/app.rs
@@ -118,3 +118,34 @@ pub fn run(path: &Path, read_only: bool) -> Result<()> {
 
     Ok(())
 }
+
+pub fn run_plain(path: &Path, read_only: bool, json: bool) -> Result<()> {
+    let env = open_env(path, read_only)?;
+    let mut names = list_databases(&env)?;
+    names.sort();
+    let output = if json {
+        serde_json::to_string_pretty(&names)? + "\n"
+    } else {
+        names.join("\n") + "\n"
+    };
+    output_with_pager(&output)?;
+    Ok(())
+}
+
+fn output_with_pager(text: &str) -> io::Result<()> {
+    if let Ok(pager) = std::env::var("PAGER") {
+        if !pager.is_empty() {
+            let mut child = std::process::Command::new(pager)
+                .stdin(std::process::Stdio::piped())
+                .spawn()?;
+            if let Some(stdin) = &mut child.stdin {
+                use std::io::Write;
+                stdin.write_all(text.as_bytes())?;
+            }
+            child.wait()?;
+            return Ok(());
+        }
+    }
+    print!("{}", text);
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,18 @@ use std::path::PathBuf;
 
 use clap::{command, Parser};
 
+use heed::Error as HeedError;
 use lmdb_tui::app;
 
 /// Simple LMDB TUI explorer
 #[derive(Debug, Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(
+    author,
+    version,
+    about = "Simple LMDB TUI explorer",
+    arg_required_else_help = true,
+    after_help = "Examples:\n  lmdb-tui path/to/env\n  lmdb-tui --plain path/to/env\n\nFull docs: https://lmdb.nibzard.com"
+)]
 struct Cli {
     /// Path to the LMDB environment directory
     path: PathBuf,
@@ -14,12 +21,59 @@ struct Cli {
     /// Open environment read-only
     #[arg(long)]
     read_only: bool,
+
+    /// Output plain text instead of TUI
+    #[arg(long, conflicts_with = "json")]
+    plain: bool,
+
+    /// Output JSON instead of TUI
+    #[arg(long, conflicts_with = "plain")]
+    json: bool,
+
+    /// Reduce output to errors only
+    #[arg(short, long)]
+    quiet: bool,
+
+    /// Show verbose debug messages
+    #[arg(long)]
+    verbose: bool,
 }
 
 fn main() {
     let cli = Cli::parse();
-    if let Err(e) = app::run(&cli.path, cli.read_only) {
-        eprintln!("error: {e}");
-        std::process::exit(1);
+
+    if cli.verbose || std::env::var_os("DEBUG").is_some() {
+        eprintln!("debug: opening {}", cli.path.display());
+    }
+
+    let res = if cli.plain || cli.json {
+        app::run_plain(&cli.path, cli.read_only, cli.json)
+    } else {
+        app::run(&cli.path, cli.read_only)
+    };
+
+    if let Err(e) = res {
+        if !cli.quiet {
+            eprintln!("error: {e}");
+        }
+        let code = if e
+            .downcast_ref::<std::io::Error>()
+            .map(|io| io.kind() == std::io::ErrorKind::NotFound)
+            .unwrap_or_else(|| {
+                e.downcast_ref::<HeedError>()
+                    .and_then(|heed_err| {
+                        if let HeedError::Io(io) = heed_err {
+                            Some(io.kind() == std::io::ErrorKind::NotFound)
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or(false)
+            }) {
+            2
+        } else {
+            1
+        };
+        std::process::exit(code);
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -18,3 +18,43 @@ fn shows_help() {
         .success()
         .stdout(contains("Simple LMDB TUI explorer"));
 }
+
+#[test]
+fn no_args_shows_help() {
+    let mut cmd = Command::cargo_bin("lmdb-tui").unwrap();
+    cmd.assert().failure().code(2).stderr(contains("Usage:"));
+}
+
+#[test]
+fn help_contains_readme_link() {
+    let mut cmd = Command::cargo_bin("lmdb-tui").unwrap();
+    cmd.arg("--help");
+    cmd.assert()
+        .success()
+        .stdout(contains("https://lmdb.nibzard.com"));
+}
+
+#[test]
+fn plain_lists_databases() -> anyhow::Result<()> {
+    use heed::types::Unit;
+    use lmdb_tui::db::env::open_env;
+    use tempfile::tempdir;
+
+    let dir = tempdir()?;
+    let env = open_env(dir.path(), false)?;
+    let mut tx = env.write_txn()?;
+    env.create_database::<Unit, Unit>(&mut tx, Some("foo"))?;
+    tx.commit()?;
+
+    let mut cmd = Command::cargo_bin("lmdb-tui").unwrap();
+    cmd.args(["--plain", dir.path().to_str().unwrap()]);
+    cmd.assert().success().stdout(contains("foo"));
+    Ok(())
+}
+
+#[test]
+fn missing_env_exits_with_code_2() {
+    let mut cmd = Command::cargo_bin("lmdb-tui").unwrap();
+    cmd.arg("/nonexistent");
+    cmd.assert().failure().code(2);
+}


### PR DESCRIPTION
## Summary
- show help when no args and link README
- add `--plain` and `--json` modes
- respect `$DEBUG` and `$PAGER`
- add quiet/verbose flags and map common errors to exit codes
- document new behaviour in specs and mark tasks done
- extend CLI tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68420beb9f2c83208cb6b3349084d052