### PR TITLE
Enhance CLI UX and logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,6 +328,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,6 +617,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jiff"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jsonpath_lib"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,8 +688,10 @@ dependencies = [
  "assert_cmd",
  "clap",
  "crossterm",
+ "env_logger",
  "heed",
  "jsonpath_lib",
+ "log",
  "predicates",
  "ratatui",
  "regex",
@@ -832,6 +881,21 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 jsonpath_lib = "0.3"
+log = "0.4"
+env_logger = "0.11"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -16,5 +16,13 @@ fn shows_help() {
     cmd.arg("--help");
     cmd.assert()
         .success()
-        .stdout(contains("Simple LMDB TUI explorer"));
+        .stdout(contains("Simple LMDB TUI explorer"))
+        .stdout(contains("https://lmdb.nibzard.com"));
+}
+
+#[test]
+fn missing_env_returns_code_2() {
+    let mut cmd = Command::cargo_bin("lmdb-tui").unwrap();
+    cmd.arg("/no/such/path");
+    cmd.assert().code(2);
 }


### PR DESCRIPTION
## Summary
- improve help text with README link and pager support
- add --plain, --json, -q and --verbose flags
- respect DEBUG and PAGER env vars
- map IO errors to exit codes
- update CLI tests

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -q`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6842096975a88320b8341685e501e6dc