### PR TITLE
[Team1] Improve job queue cleanup and pager handling

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -15,8 +15,12 @@ use crate::db::stats::{DbStats, EnvStats};
 use crate::jobs::{JobQueue, JobResult};
 
 use crate::config::Config;
+use crate::constants::DEFAULT_ENTRY_LIMIT;
 use crate::db::env::{list_databases, list_entries, open_env};
-use crate::ui::{self, help::{self, DEFAULT_ENTRIES}};
+use crate::ui::{
+    self,
+    help::{self, DEFAULT_ENTRIES},
+};
 use ratatui::layout::{Constraint, Direction, Layout};
 
 fn centered_rect(
@@ -106,17 +110,17 @@ impl App {
     pub fn new(env: Env, mut db_names: Vec<String>, config: Config) -> Result<Self> {
         db_names.sort();
         let entries = if let Some(name) = db_names.first() {
-            list_entries(&env, name, 100)?
+            list_entries(&env, name, DEFAULT_ENTRY_LIMIT)?
         } else {
             Vec::new()
         };
-        
+
         let job_queue = JobQueue::new(env.clone());
         job_queue.request_env_stats()?;
         if let Some(name) = db_names.first() {
             job_queue.request_db_stats(name.clone())?;
         }
-        
+
         Ok(Self {
             env,
             db_names,
@@ -154,7 +158,7 @@ impl App {
                 if !self.db_names.is_empty() {
                     self.selected = (self.selected + 1) % self.db_names.len();
                     let name = &self.db_names[self.selected];
-                    self.entries = list_entries(&self.env, name, 100)?;
+                    self.entries = list_entries(&self.env, name, DEFAULT_ENTRY_LIMIT)?;
                     self.job_queue.request_db_stats(name.clone())?;
                 }
             }
@@ -166,7 +170,7 @@ impl App {
                         self.selected -= 1;
                     }
                     let name = &self.db_names[self.selected];
-                    self.entries = list_entries(&self.env, name, 100)?;
+                    self.entries = list_entries(&self.env, name, DEFAULT_ENTRY_LIMIT)?;
                     self.job_queue.request_db_stats(name.clone())?;
                 }
             }
@@ -285,7 +289,7 @@ fn output_with_pager(text: &str) -> io::Result<()> {
             let mut child = std::process::Command::new(pager)
                 .stdin(std::process::Stdio::piped())
                 .spawn()?;
-            if let Some(stdin) = &mut child.stdin {
+            if let Some(mut stdin) = child.stdin.take() {
                 use std::io::Write;
                 stdin.write_all(text.as_bytes())?;
             }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,2 @@
+pub const DEFAULT_ENTRY_LIMIT: usize = 100;
+pub const MAX_DATABASES: u32 = 128;

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -1,4 +1,4 @@
-use std::thread;
+use std::thread::{self, JoinHandle};
 
 use anyhow::Result;
 use tokio::{sync::mpsc, task};
@@ -20,8 +20,9 @@ pub enum JobResult {
 
 /// Simple job queue backed by a Tokio runtime running in a thread.
 pub struct JobQueue {
-    sender: mpsc::UnboundedSender<Job>,
+    sender: Option<mpsc::UnboundedSender<Job>>,
     pub receiver: mpsc::UnboundedReceiver<JobResult>,
+    handle: Option<JoinHandle<()>>,
 }
 
 impl JobQueue {
@@ -29,7 +30,7 @@ impl JobQueue {
         let (tx, mut rx) = mpsc::unbounded_channel();
         let (res_tx, res_rx) = mpsc::unbounded_channel();
         let env_thread = env.clone();
-        thread::spawn(move || {
+        let handle = thread::spawn(move || {
             let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
@@ -51,12 +52,18 @@ impl JobQueue {
                         Job::Db(name) => {
                             let e = env_thread.clone();
                             let name_clone = name.clone();
-                            match task::spawn_blocking(move || stats::db_stats(&e, &name_clone)).await {
+                            match task::spawn_blocking(move || stats::db_stats(&e, &name_clone))
+                                .await
+                            {
                                 Ok(Ok(stats)) => {
                                     let _ = res_tx.send(JobResult::Db(name, stats));
                                 }
                                 Ok(Err(e)) => {
-                                    log::warn!("Failed to calculate stats for database '{}': {}", name, e);
+                                    log::warn!(
+                                        "Failed to calculate stats for database '{}': {}",
+                                        name,
+                                        e
+                                    );
                                 }
                                 Err(e) => {
                                     log::error!("Task join error for database '{}': {}", name, e);
@@ -68,16 +75,33 @@ impl JobQueue {
             });
         });
         Self {
-            sender: tx,
+            sender: Some(tx),
             receiver: res_rx,
+            handle: Some(handle),
         }
     }
 
     pub fn request_env_stats(&self) -> Result<()> {
-        Ok(self.sender.send(Job::Env)?)
+        if let Some(sender) = &self.sender {
+            sender.send(Job::Env)?;
+        }
+        Ok(())
     }
 
     pub fn request_db_stats(&self, db: String) -> Result<()> {
-        Ok(self.sender.send(Job::Db(db))?)
+        if let Some(sender) = &self.sender {
+            sender.send(Job::Db(db))?;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for JobQueue {
+    fn drop(&mut self) {
+        // Close the channel by dropping the sender before joining the thread
+        self.sender.take();
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod app;
 pub mod bookmarks;
 pub mod commands;
 pub mod config;
+pub mod constants;
 pub mod db;
 pub mod errors;
 pub mod jobs;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@ use std::process::{Command, Stdio};
 
 use clap::{command, CommandFactory, Parser};
 use heed::Error as HeedError;
-use log::LevelFilter;
 use lmdb_tui::app;
+use log::LevelFilter;
 
 /// Simple LMDB TUI explorer
 #[derive(Debug, Parser)]
@@ -61,7 +61,8 @@ fn main() {
 
 fn handle_help_pager() {
     let args: Vec<String> = std::env::args().collect();
-    if args.iter().any(|a| a == "--help" || a == "-h")
+    if args.len() == 1
+        || args.iter().any(|a| a == "--help" || a == "-h")
         || args.iter().any(|a| a == "--version" || a == "-V")
     {
         let mut cmd = Cli::command();
@@ -109,7 +110,7 @@ fn exit_code(e: &anyhow::Error) -> i32 {
         if let Some(io) = cause.downcast_ref::<std::io::Error>() {
             use std::io::ErrorKind::*;
             return match io.kind() {
-                NotFound => 2,
+                NotFound => 1,
                 PermissionDenied => 3,
                 _ => 1,
             };
@@ -117,7 +118,7 @@ fn exit_code(e: &anyhow::Error) -> i32 {
         if let Some(HeedError::Io(io)) = cause.downcast_ref::<HeedError>() {
             use std::io::ErrorKind::*;
             return match io.kind() {
-                NotFound => 2,
+                NotFound => 1,
                 PermissionDenied => 3,
                 _ => 1,
             };


### PR DESCRIPTION
## Summary
- add shared constants for entry limit and max databases
- cleanly terminate background job thread
- fix pager stdin leak
- handle no-args case in help pager
- adjust error code mapping for `NotFound`

## Testing
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6843f79d6c64832096f63aaa227761c1